### PR TITLE
security: CWE-295: Enable TLS verification by default — VC-53746

### DIFF
--- a/pytpp/api/session.py
+++ b/pytpp/api/session.py
@@ -15,11 +15,9 @@ class Session:
     """
 
     def __init__(self, headers: dict, proxies: dict = None, certificate_path: str = None,
-                 key_file_path: str = None, verify_ssl: bool = False, tpp_version: 'Version' = None,
+                 key_file_path: str = None, verify_ssl: bool = True, tpp_version: 'Version' = None,
                  connection_timeout: float = None, read_timeout: float = None):
         self.requests = requests
-        # noinspection PyUnresolvedReferences
-        self.requests.packages.urllib3.disable_warnings()
         self.request_kwargs = {
             'headers': headers,
             'verify' : verify_ssl,


### PR DESCRIPTION
## Summary

Fixes CWE-295 (Improper Certificate Validation) by changing the default TLS verification setting from `verify=False` to `verify=True` in the Session class.

## Finding

**CVSS:** 7.5 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N)  
**CWE:** CWE-295 (Improper Certificate Validation)

The pytpp library's session module used `verify=False` as the default for TLS verification. This disabled certificate chain validation, hostname verification, and certificate expiry checking for all TPP API calls. An on-path attacker could terminate the TLS connection with any certificate and intercept authentication tokens and API data.

## Remediation

Changed `pytpp/api/session.py` to:
1. **Set secure default**: Changed `verify_ssl` parameter default from `False` to `True` in the Session class `__init__` method
2. **Removed warning suppression**: Removed the global `disable_warnings()` call that suppressed InsecureRequestWarning

All TPP API connections now enforce TLS certificate validation by default. Users who need to connect to servers with self-signed certificates can still explicitly pass `verify_ssl=False` or provide a custom CA bundle path.

## Verification

- Pattern-C security remediation applied
- Build: No build system detected (Python library)
- Tests: No tests found in repository (exit code 5)
- Changes limited to security-critical defaults in session.py
